### PR TITLE
Add due date and module name

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ soup_upcoming_events = BeautifulSoup(upcoming_events, 'lxml')
 
 events = soup_upcoming_events.find_all('div', class_='card rounded')
 
-print("Upcoming assignments that you have not submitted yet: ")
+print("\nUpcoming assignments that you have not submitted yet: ")
 i = 0
 for event in events:
     event_name = event.find('h3').text
@@ -43,11 +43,20 @@ for event in events:
 
     event_page = session.get(event_link).text
     soup_event_page = BeautifulSoup(event_page, 'lxml')
+    event_details = soup_event_page.find_all('td', class_='cell c1 lastcol')
+    module_name = soup_event_page.find('h1').text
+    due_date = event_details[1].text;
+    remaining_time = event_details[2].text;
     submitted = soup_event_page.find_all(
         'td', class_='submissionstatussubmitted cell c1 lastcol')
     if not submitted:
         i += 1
-        print(f'{i}| {event_name}: {event_link}')
+        print()
+        print(f'{i}) {module_name} - {event_name}')
+        print(f'   - {due_date}')
+        print(f'   - {remaining_time}')
+        print(f'   - {event_link}')
+        print()
 
 # No upcoming assignments
 if(i == 0):


### PR DESCRIPTION
### Approach
- Retrieved the `td` array on the event page 
- Took `[1]` and `[2]` elements to get the remaining days and due date
- Caught the `h1` on the event page to get the module name
- Improved the CLI output structure a bit

### Screenshot 
![image](https://user-images.githubusercontent.com/45477334/122521295-4769f280-d032-11eb-8822-db367e18caf9.png)

#### Please feel free to request changes 😉 